### PR TITLE
AWS Environment Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gconfig"
-version = "0.1.13"
+version = "0.1.14"
 description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gconfig"
-version = "0.2.1"
+version = "0.2.0"
 description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,10 @@
 [project]
 name = "gconfig"
-version = "0.1.9"
-description="Gordian global config library for Python"
+version = "0.1.13"
+description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"
-authors = [
-    { name = "Koray Gocmen", email = "koray@gordiansoftware.com" }
-]
+authors = [{ name = "Koray Gocmen", email = "koray@gordiansoftware.com" }]
 
 [build-system]
 requires = ["setuptools>=46.4.0", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gconfig"
-version = "0.1.15"
+version = "0.2.0"
 description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [project]
 name = "gconfig"
-version = "0.1.14"
+version = "0.1.15"
 description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"
-authors = [{ name = "Koray Gocmen", email = "koray@gordiansoftware.com" }]
+authors = [
+    { name = "Koray Gocmen", email = "koray@gordiansoftware.com" },
+    { name = "Jakub Klapacz", email = "jakub@gordiansoftware.com" },
+]
 
 [build-system]
 requires = ["setuptools>=46.4.0", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gconfig"
-version = "0.2.0"
+version = "0.2.1"
 description = "Gordian global config library for Python"
 license = { file = "LICENSE" }
 requires-python = ">=2.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.1.12"
+version = "0.1.13"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.2.0"
+version = "0.2.1"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.2.1"
+version = "0.2.0"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.1.9"
+version = "0.1.12"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,5 @@ description="Gordian global config library for Python"
 python_requires = >=2.7
 package_dir =
     = src
+install_requires =
+    boto3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.1.14"
+version = "0.2.0"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = "gconfig"
-version = "0.1.13"
+version = "0.1.14"
 license_files = LICENSE
 author = "Koray Gocmen"
 author_email = koray@gordiansoftware.com

--- a/src/gconfig/__init__.py
+++ b/src/gconfig/__init__.py
@@ -9,7 +9,7 @@ from .exceptions import (AWSInvalidCredentialsException,
                          AWSMissingSessionTokenException)
 from .parse import parse_entry
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = [
     'AWSInvalidCredentialsException',
     'AWSInvalidSessionException',

--- a/src/gconfig/__init__.py
+++ b/src/gconfig/__init__.py
@@ -1,26 +1,30 @@
 from .cache import Cache, CacheEntry
 from .config import Config
-from .exceptions import (AWSInvalidCredentialsException,
-                         AWSInvalidSessionException,
-                         AWSMissingAccessKeyIdException,
-                         AWSMissingRegionException, AWSMissingRoleARNException,
-                         AWSMissingRoleSessionNameException,
-                         AWSMissingSecretAccessKeyException,
-                         AWSMissingSessionTokenException)
+from .exceptions import (
+    AWSInvalidCredentialsException,
+    AWSInvalidSessionException,
+    AWSMissingAccessKeyIdException,
+    AWSMissingRegionException,
+    AWSMissingRoleARNException,
+    AWSMissingRoleSessionNameException,
+    AWSMissingSecretAccessKeyException,
+    AWSMissingSessionTokenException,
+)
 from .parse import parse_entry
 
-__version__ = "0.2.1"
 __all__ = [
-    'AWSInvalidCredentialsException',
-    'AWSInvalidSessionException',
-    'AWSMissingAccessKeyIdException',
-    'AWSMissingRegionException',
-    'AWSMissingRoleARNException',
-    'AWSMissingRoleSessionNameException',
-    'AWSMissingSecretAccessKeyException',
-    'AWSMissingSessionTokenException',
-    'Config',
-    'Cache',
-    'CacheEntry',
-    'parse_entry'
+    "AWSInvalidCredentialsException",
+    "AWSInvalidSessionException",
+    "AWSMissingAccessKeyIdException",
+    "AWSMissingRegionException",
+    "AWSMissingRoleARNException",
+    "AWSMissingRoleSessionNameException",
+    "AWSMissingSecretAccessKeyException",
+    "AWSMissingSessionTokenException",
+    "Cache",
+    "CacheEntry",
+    "Config",
+    "parse_entry",
 ]
+
+__version__ = "0.2.0"

--- a/src/gconfig/__init__.py
+++ b/src/gconfig/__init__.py
@@ -1,4 +1,26 @@
-from .config import *
-from .exceptions import *
-from .cache import *
-from .parse import *
+from .cache import Cache, CacheEntry
+from .config import Config
+from .exceptions import (AWSInvalidCredentialsException,
+                         AWSInvalidSessionException,
+                         AWSMissingAccessKeyIdException,
+                         AWSMissingRegionException, AWSMissingRoleARNException,
+                         AWSMissingRoleSessionNameException,
+                         AWSMissingSecretAccessKeyException,
+                         AWSMissingSessionTokenException)
+from .parse import parse_entry
+
+__version__ = "0.2.0"
+__all__ = [
+    'AWSInvalidCredentialsException',
+    'AWSInvalidSessionException',
+    'AWSMissingAccessKeyIdException',
+    'AWSMissingRegionException',
+    'AWSMissingRoleARNException',
+    'AWSMissingRoleSessionNameException',
+    'AWSMissingSecretAccessKeyException',
+    'AWSMissingSessionTokenException',
+    'Config',
+    'Cache',
+    'CacheEntry',
+    'parse_entry'
+]

--- a/src/gconfig/cache.py
+++ b/src/gconfig/cache.py
@@ -1,6 +1,4 @@
-from ast import Dict
-from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 
 class CacheEntry:

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -49,16 +49,19 @@ class Config:
 
                 self.aws_role_arn = aws_role_arn
                 self.aws_role_session_name = aws_role_session_name
+
                 session = boto3.Session(
                     aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key,
                 )
+
                 sts = session.client("sts")
                 assumed_role_object = sts.assume_role(
                     RoleArn=self.aws_role_arn,
                     RoleSessionName=self.aws_role_session_name,
                 )
                 credentials = assumed_role_object.get("Credentials")
+
                 # Override the credentials with the assumed role credentials.
                 aws_access_key_id = credentials.get("AccessKeyId")
                 aws_secret_access_key = credentials.get("SecretAccessKey")

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -34,8 +34,8 @@ class Config:
             )
             region_name = os.environ.get(f"{self.aws_prefix}AWS_REGION")
 
-            if aws_access_key_id is None:
-                raise exceptions.AWSMissingAccessKeyIdException
+            # if aws_access_key_id is None:
+                # raise exceptions.AWSMissingAccessKeyIdException
 
             # if aws_secret_access_key is None:
                 # raise exceptions.AWSMissingSecretAccessKeyException

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -7,6 +7,9 @@ from botocore.exceptions import ClientError
 from . import cache, exceptions, parse
 
 
+def debug(*args, **kwargs):
+    print(*args, **kwargs)
+
 class Config:
     def __init__(
         self,
@@ -23,6 +26,7 @@ class Config:
 
     # Secrets Manager
     def get_secretsmanager(self) -> boto3.client:
+        debug("--- getting secretsmanager client ---")
         if self.secretsmanager_client is None:
             aws_access_key_id = os.environ.get(f"{self.aws_prefix}AWS_ACCESS_KEY_ID")
             aws_secret_access_key = os.environ.get(

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -315,5 +315,3 @@ class Config:
                 change_callback_fn=change_callback_fn,
             ),
         )
-            ),
-        )

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -7,9 +7,6 @@ from botocore.exceptions import ClientError
 from . import cache, exceptions, parse
 
 
-def debug(*args, **kwargs):
-    print(*args, **kwargs)
-
 class Config:
     def __init__(
         self,
@@ -26,7 +23,6 @@ class Config:
 
     # Secrets Manager
     def get_secretsmanager(self) -> boto3.client:
-        debug("--- getting secretsmanager client ---")
         if self.secretsmanager_client is None:
             aws_access_key_id = os.environ.get(f"{self.aws_prefix}AWS_ACCESS_KEY_ID")
             aws_secret_access_key = os.environ.get(
@@ -87,11 +83,6 @@ class Config:
             # session token must be set now.
             # if aws_session_token is None:
                 # raise exceptions.AWSMissingSessionTokenException
-            debug("--- getting boto3 session ---")
-            debug(f"aws_access_key_id: {aws_access_key_id}")
-            debug(f"aws_secret_access_key: {aws_secret_access_key}")
-            debug(f"aws_session_token: {aws_session_token}")
-            debug(f"region_name: {region_name}")
 
             session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -1,8 +1,10 @@
-import os, boto3
-from typing import Optional, Callable, Dict
+import os
+from typing import Callable, Dict, Optional
+
+import boto3
 from botocore.exceptions import ClientError
 
-from . import exceptions, cache, parse
+from . import cache, exceptions, parse
 
 
 class Config:
@@ -28,54 +30,59 @@ class Config:
             )
             region_name = os.environ.get(f"{self.aws_prefix}AWS_REGION")
 
-            if aws_access_key_id is None:
-                raise exceptions.AWSMissingAccessKeyIdException
+            # if aws_access_key_id is None:
+                # raise exceptions.AWSMissingAccessKeyIdException
 
-            if aws_secret_access_key is None:
-                raise exceptions.AWSMissingSecretAccessKeyException
+            # if aws_secret_access_key is None:
+                # raise exceptions.AWSMissingSecretAccessKeyException
 
-            if region_name is None:
-                raise exceptions.AWSMissingRegionException
+            # if region_name is None:
+                # raise exceptions.AWSMissingRegionException
 
             # AWS_SESSION_TOKEN is optional, if not provided, assume role will be used.
             aws_session_token = os.environ.get(f"{self.aws_prefix}AWS_SESSION_TOKEN")
 
             # If AWS_SESSION_TOKEN is not provided, assume role.
             if aws_session_token is None:
-                aws_role_arn = os.environ.get(f"{self.aws_prefix}AWS_ROLE_ARN")
+                aws_role_arn = os.environ.get(f"{self.aws_prefix}AWS_ROLE_ARN", None)
                 aws_role_session_name = os.environ.get(
-                    f"{self.aws_prefix}AWS_ROLE_SESSION_NAME"
+                    f"{self.aws_prefix}AWS_ROLE_SESSION_NAME", None
                 )
 
-                if aws_role_arn is None:
-                    raise exceptions.AWSMissingRoleARNException
+                # if aws_role_arn is None:
+                    # raise exceptions.AWSMissingRoleARNException
 
-                if aws_role_session_name is None:
-                    raise exceptions.AWSMissingRoleSessionNameException
+                # if aws_role_session_name is None:
+                    # raise exceptions.AWSMissingRoleSessionNameException
 
                 self.aws_role_arn = aws_role_arn
                 self.aws_role_session_name = aws_role_session_name
-
-                session = boto3.Session(
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
-                )
-
-                sts = session.client("sts")
-                assumed_role_object = sts.assume_role(
-                    RoleArn=self.aws_role_arn,
-                    RoleSessionName=self.aws_role_session_name,
-                )
-                credentials = assumed_role_object.get("Credentials")
-
-                # Override the credentials with the assumed role credentials.
-                aws_access_key_id = credentials.get("AccessKeyId")
-                aws_secret_access_key = credentials.get("SecretAccessKey")
-                aws_session_token = credentials.get("SessionToken")
+                
+                if aws_access_key_id and aws_secret_access_key:
+                    session = boto3.Session(
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
+                    )
+    
+                    sts = session.client("sts")
+                    assumed_role_object = sts.assume_role(
+                        RoleArn=self.aws_role_arn,
+                        RoleSessionName=self.aws_role_session_name,
+                    )
+                    credentials = assumed_role_object.get("Credentials")
+    
+                    # Override the credentials with the assumed role credentials.
+                    aws_access_key_id = credentials.get("AccessKeyId")
+                    aws_secret_access_key = credentials.get("SecretAccessKey")
+                    aws_session_token = credentials.get("SessionToken")
+                else:
+                    aws_access_key_id = None
+                    aws_secret_access_key = None
+                    aws_session_token = None
 
             # session token must be set now.
-            if aws_session_token is None:
-                raise exceptions.AWSMissingSessionTokenException
+            # if aws_session_token is None:
+                # raise exceptions.AWSMissingSessionTokenException
 
             session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,
@@ -306,5 +313,7 @@ class Config:
                 required=required,
                 default=default,
                 change_callback_fn=change_callback_fn,
+            ),
+        )
             ),
         )

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -49,19 +49,16 @@ class Config:
 
                 self.aws_role_arn = aws_role_arn
                 self.aws_role_session_name = aws_role_session_name
-                
                 session = boto3.Session(
                     aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key,
                 )
-    
                 sts = session.client("sts")
                 assumed_role_object = sts.assume_role(
                     RoleArn=self.aws_role_arn,
                     RoleSessionName=self.aws_role_session_name,
                 )
                 credentials = assumed_role_object.get("Credentials")
-    
                 # Override the credentials with the assumed role credentials.
                 aws_access_key_id = credentials.get("AccessKeyId")
                 aws_secret_access_key = credentials.get("SecretAccessKey")

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -34,8 +34,8 @@ class Config:
             )
             region_name = os.environ.get(f"{self.aws_prefix}AWS_REGION")
 
-            # if aws_access_key_id is None:
-                # raise exceptions.AWSMissingAccessKeyIdException
+            if aws_access_key_id is None:
+                raise exceptions.AWSMissingAccessKeyIdException
 
             # if aws_secret_access_key is None:
                 # raise exceptions.AWSMissingSecretAccessKeyException

--- a/src/gconfig/config.py
+++ b/src/gconfig/config.py
@@ -87,6 +87,11 @@ class Config:
             # session token must be set now.
             # if aws_session_token is None:
                 # raise exceptions.AWSMissingSessionTokenException
+            debug("--- getting boto3 session ---")
+            debug(f"aws_access_key_id: {aws_access_key_id}")
+            debug(f"aws_secret_access_key: {aws_secret_access_key}")
+            debug(f"aws_session_token: {aws_session_token}")
+            debug(f"region_name: {region_name}")
 
             session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,


### PR DESCRIPTION
This PR introduces a minor change to the functionality of gconfig.

Currently gconfig does not support running in an AWS environment: specifically, gconfig does not utilize the default botocore behaviors which involve pulling credentials from the AWS environment; instead the user has to configure the environment with an AWS access key.

This PR changes this functionality: if no AWS secrets are able to be pulled from the environment the assumption is that assume role is not needed: the runtime role of the environment (e.g the task role of an ecs task) will have to have the permissions necessary to access the correct secrets manager secrets.